### PR TITLE
Fixed #1 : Duplicated key-word assignment and usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bbackup.conf

--- a/bbackup.conf
+++ b/bbackup.conf
@@ -66,7 +66,7 @@ export SEC_SHARE="//192.168.1.210/Backup_Monthly"
 # COMP_DEL => is the DELIMITER used for splitting the string.
 # COMP_SRC => defines the source(s) what the script takes as input.
 # COMP_TMP => all the files/folders are going to be stored in here.
-# COMP_DEL => set this flag if the script should delete existing files in the COMP_TMP path.
+# COMP_REM => set this flag if the script should delete existing files in the COMP_TMP path.
 #
 export TRIES=3
 export JOB="hourly"
@@ -75,7 +75,7 @@ export COMPRESS=1
 export COMP_DEL=";"
 export COMP_SRC="/etc/;/home/;/var/log/"
 export COMP_TMP="/tmp/bbackup/"
-export COMP_DEL=1
+export COMP_REM=1
 
 ##########################################################
 #                  Logging information                   #

--- a/bbackup.default.conf
+++ b/bbackup.default.conf
@@ -66,7 +66,7 @@ export SEC_SHARE="//192.168.0.100/Backup2"
 # COMP_DEL => is the DELIMITER used for splitting the string.
 # COMP_SRC => defines the source(s) what the script takes as input.
 # COMP_TMP => all the files/folders are going to be stored in here.
-# COMP_DEL => set this flag if the script should delete existing files in the COMP_TMP path.
+# COMP_REM => set this flag if the script should delete existing files in the COMP_TMP path.
 #
 export TRIES=3
 export JOB="hourly"
@@ -75,7 +75,7 @@ export COMPRESS=0
 export COMP_DEL=";"
 export COMP_SRC="/etc/;/home/;/var/log/"
 export COMP_TMP="/tmp/bbackup/"
-export COMP_DEL=1
+export COMP_REM=1
 
 ##########################################################
 #                  Logging information                   #

--- a/bbackup.sh
+++ b/bbackup.sh
@@ -119,7 +119,7 @@ compress() {
 	#
 	if [ -d $dest ]; then
 		# Check if the trigger is defined.
-        	if [[ $COMP_DEL == 1 ]]; then
+        	if [[ $COMP_REM == 1 ]]; then
             		log "Trying to delete [$dest]." "DEBUG"
 			{
             			rm -rf $dest 2>&1 /dev/null


### PR DESCRIPTION
The `$COMP_DEL` (compression_delimiter) was also used as the compression_delete (`$COMP_DEL`) flag.
Changed the key-word from `$COMP_DEL` to `$COMP_REM` so the script gets the flag and the delimiter.

From: `line 122         if [[ $COMP_DEL == 1 ]]; then`
To: `line 122         if [[ $COMP_REM == 1 ]]; then`

"Fixed" #1 